### PR TITLE
Add docs on dependency support policies

### DIFF
--- a/development.md
+++ b/development.md
@@ -1,0 +1,19 @@
+---
+description: Instructions and conventions for developing BrainGlobe projects
+---
+
+# Development
+
+## Dependency support
+Packages have to choose which versions of dependencies they officially support,
+with minimum supported versions of each dependency used in continuous
+integration testing. BrainGlobe projects should follow
+[NEP 29 — Recommend Python and NumPy version support as a community policy
+standard](https://numpy.org/neps/nep-0029-deprecation_policy.html) to
+determine the **minimum** set of supported package versions:
+
+- The last 42 months of Python releases
+- The last 24 months of NumPy releases
+
+In addition to this the last 24 months of other dependencies should also be
+supported.


### PR DESCRIPTION
This adds guidance on the minimum timeframe for supporting versions of package dependencies. Once this is settled on it can be used to work out which Python/dependency versions to test across on BrainGlobe projects. Definitely open for discussion!

I'm imaginging this page can grow to add BrainGlobe-wide policies/conventions.